### PR TITLE
[codex] Restore friend drift nudges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,9 @@ DATABASE_URL=postgresql://postgres:sE7Zf$k_wkT2VWZ@db.fjufukkcezipmnfeibkt.supab
 ENVIRONMENT=development  # "development" | "pilot"
 ALLOWED_ORIGINS=*        # Comma-separated origins for CORS
 LOG_LEVEL=info
+
+# -- Firebase Cloud Messaging --
+# Preferred for Railway/hosted deploys: paste the Firebase service account JSON.
+FIREBASE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}
+# Alternative for local/dev machines: point to a downloaded service account file.
+GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/firebase-service-account.json

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The API runs at `http://localhost:8000`. Health check: `GET /health`.
 | `ENVIRONMENT` | | `development` (default), `pilot`, or `production` |
 | `ALLOWED_ORIGINS` | | Comma-separated CORS origins (default `*`) |
 | `LOG_LEVEL` | | `debug`, `info` (default), `warning`, `error` |
+| `FIREBASE_SERVICE_ACCOUNT_JSON` | For push notifications | Firebase service account JSON, preferred on Railway |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Alternative for push notifications | Absolute path to a Firebase service account JSON file |
 
 ## API Routes
 

--- a/app/routers/nudges.py
+++ b/app/routers/nudges.py
@@ -103,6 +103,24 @@ def _compute_nudge_tier(days_since_activity: int) -> Optional[str]:
     return None
 
 
+def _compute_effective_nudge_tier(
+    days_since_activity: int,
+    suggested_friend: Optional[FriendSuggestion],
+) -> Optional[str]:
+    """
+    Reminder nudges are friend-drift nudges first.
+
+    A user can be generally active while one friendship has gone quiet. In that
+    case, use the suggested friend's gap instead of suppressing the nudge just
+    because the user recently checked in or contacted someone else.
+    """
+    if suggested_friend is not None:
+        friend_tier = _compute_nudge_tier(suggested_friend.days_since_contact)
+        if friend_tier is not None:
+            return friend_tier
+    return _compute_nudge_tier(days_since_activity)
+
+
 def _pick_copy(tier: str, friend_name: Optional[str] = None) -> str:
     import random
     variants = NUDGE_COPY.get(tier, NUDGE_COPY["gentle_observation"])
@@ -220,7 +238,7 @@ def get_warmth(
             )
 
     tier = _compute_warmth_tier(week_streak, had_activity_this_week)
-    nudge_tier = _compute_nudge_tier(days_since)
+    nudge_tier = _compute_effective_nudge_tier(days_since, suggested)
 
     return WarmthSnapshot(
         warmth_tier=tier,
@@ -252,10 +270,21 @@ def check_nudge_eligibility(
 
     friend_name = warmth.suggested_friend.friend_name if warmth.suggested_friend else None
     copy = _pick_copy(warmth.nudge_tier, friend_name)
+    if warmth.suggested_friend:
+        reason = (
+            f"{warmth.suggested_friend.friend_name} has drifted for "
+            f"{warmth.suggested_friend.days_since_contact} days — "
+            f"{warmth.nudge_tier} tier"
+        )
+    else:
+        reason = (
+            f"User absent for {warmth.days_since_outreach} days — "
+            f"{warmth.nudge_tier} tier"
+        )
 
     return NudgeEligibility(
         eligible=True,
-        reason=f"User absent for {warmth.days_since_outreach} days — {warmth.nudge_tier} tier",
+        reason=reason,
         nudge_tier=warmth.nudge_tier,
         copy=copy,
         friend_name=friend_name,

--- a/app/services/push_dispatcher.py
+++ b/app/services/push_dispatcher.py
@@ -23,10 +23,18 @@ def _get_firebase():
     try:
         import firebase_admin
         from firebase_admin import credentials
+        import json
         import os
 
+        cred_json = (
+            os.environ.get("FIREBASE_SERVICE_ACCOUNT_JSON")
+            or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+        )
         cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-        if cred_path:
+        if cred_json:
+            cred = credentials.Certificate(json.loads(cred_json))
+            _firebase_app = firebase_admin.initialize_app(cred)
+        elif cred_path:
             cred = credentials.Certificate(cred_path)
             _firebase_app = firebase_admin.initialize_app(cred)
         else:

--- a/tests/test_nudges.py
+++ b/tests/test_nudges.py
@@ -1,0 +1,69 @@
+import unittest
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_nudges_module():
+    repo_module = types.ModuleType("app.db.repository")
+    repo_module.Repository = type("Repository", (), {})
+    deps_module = types.ModuleType("app.dependencies")
+    deps_module.get_current_user_id = lambda: "user-1"
+    deps_module.get_repository = lambda: repo_module.Repository()
+    sys.modules["app.db.repository"] = repo_module
+    sys.modules["app.dependencies"] = deps_module
+
+    module_path = Path(__file__).resolve().parents[1] / "app" / "routers" / "nudges.py"
+    spec = importlib.util.spec_from_file_location("nudges_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+nudges = _load_nudges_module()
+
+
+class EffectiveNudgeTierTests(unittest.TestCase):
+    def test_friend_drift_triggers_nudge_even_when_user_is_active(self):
+        suggested = nudges.FriendSuggestion(
+            friend_id="friend-1",
+            friend_name="Alex",
+            days_since_contact=15,
+        )
+
+        self.assertEqual(
+            nudges._compute_effective_nudge_tier(
+                days_since_activity=0,
+                suggested_friend=suggested,
+            ),
+            "caring_concern",
+        )
+
+    def test_recent_friend_does_not_create_false_positive(self):
+        suggested = nudges.FriendSuggestion(
+            friend_id="friend-1",
+            friend_name="Alex",
+            days_since_contact=2,
+        )
+
+        self.assertIsNone(
+            nudges._compute_effective_nudge_tier(
+                days_since_activity=0,
+                suggested_friend=suggested,
+            )
+        )
+
+    def test_global_absence_still_triggers_when_no_friend_suggestion_exists(self):
+        self.assertEqual(
+            nudges._compute_effective_nudge_tier(
+                days_since_activity=7,
+                suggested_friend=None,
+            ),
+            "warm_invitation",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use the longest-drifted suggested friend when deciding reminder-nudge eligibility
- support Firebase Admin credentials from JSON env vars for deploy environments
- document Firebase credential options
- add focused tests for friend drift nudge tier selection

## Validation
- python3 -m unittest discover -s tests
- python3 -m compileall app tests
- git diff --check