### PR TITLE
[codex] Wire support beacon push alerts

### DIFF
--- a/app/routers/signals.py
+++ b/app/routers/signals.py
@@ -17,6 +17,7 @@ presence signal — "someone you care about could use warmth."
 """
 
 from datetime import datetime, timedelta, timezone
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -24,8 +25,10 @@ from uuid import UUID
 
 from app.db.repository import Repository
 from app.dependencies import get_current_user_id, get_repository
+from app.services.push_dispatcher import dispatch_beacon_alert
 
 router = APIRouter(prefix="/signals", tags=["signals"])
+logger = logging.getLogger("friendly.signals")
 
 # --------------------------------------------------------------------------
 # Request / response models
@@ -43,6 +46,8 @@ class CareSignalResponse(BaseModel):
 class BeaconResponse(BaseModel):
     active: bool
     activated_at: str | None = None
+    notified_count: int = 0
+    reachable_friends: int = 0
 
 
 class FriendBeacon(BaseModel):
@@ -140,8 +145,14 @@ def activate_beacon(
         value=1.0,
         tags=["beacon"],
     )
+    delivery = _dispatch_beacon_to_friends(repo, user_id)
 
-    return BeaconResponse(active=True, activated_at=signal.get("created_at"))
+    return BeaconResponse(
+        active=True,
+        activated_at=signal.get("created_at"),
+        notified_count=delivery["sent"],
+        reachable_friends=delivery["reachable"],
+    )
 
 
 @router.delete("/beacon", response_model=BeaconResponse)
@@ -275,3 +286,47 @@ def _parse_ts(ts_str: str) -> datetime:
         return dt
     except (ValueError, TypeError):
         return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _confirmed_friend_ids(repo: Repository, user_id: str) -> list[str]:
+    friendships = repo.list_friendships(user_id)
+    friend_ids: list[str] = []
+    seen: set[str] = set()
+    for f in friendships:
+        if f.get("status") != "confirmed":
+            continue
+        friend_id = None
+        if f.get("user_id") == user_id:
+            friend_id = f.get("friend_id")
+        elif f.get("friend_id") == user_id:
+            friend_id = f.get("user_id")
+        if friend_id and friend_id not in seen:
+            seen.add(friend_id)
+            friend_ids.append(friend_id)
+    return friend_ids
+
+
+def _dispatch_beacon_to_friends(repo: Repository, user_id: str) -> dict[str, int]:
+    profile = repo.get_profile(user_id) or {}
+    sender_name = profile.get("display_name") or "A friend"
+    sent = 0
+    reachable = 0
+
+    for friend_id in _confirmed_friend_ids(repo, user_id):
+        try:
+            result = dispatch_beacon_alert(repo, friend_id, user_id, sender_name)
+        except Exception as e:
+            logger.warning(f"Beacon alert dispatch failed for friend {friend_id}: {e}")
+            continue
+        if result.get("reachable"):
+            reachable += 1
+        if result.get("sent"):
+            sent += 1
+
+    logger.info(
+        "Beacon activated for %s; sent %s/%s reachable friend alerts",
+        user_id,
+        sent,
+        reachable,
+    )
+    return {"sent": sent, "reachable": reachable}

--- a/app/services/push_dispatcher.py
+++ b/app/services/push_dispatcher.py
@@ -129,3 +129,54 @@ def dispatch_nudge(repo, user_id: str, nudge_tier: str, copy_text: str,
         repo.increment_nudge_cycle(user_id)
 
     return success
+
+
+def dispatch_beacon_alert(
+    repo,
+    recipient_id: str,
+    sender_id: str,
+    sender_name: str,
+) -> dict[str, bool | str]:
+    """
+    Send a user-triggered support beacon alert to one confirmed friend.
+
+    Beacon alerts are separate from absence nudges: they respect the recipient's
+    beacon preference and push token, but do not consume daily nudge limits.
+    """
+    profile = repo.get_profile(recipient_id)
+    if not profile:
+        return {"sent": False, "reachable": False, "reason": "missing_profile"}
+
+    metadata = profile.get("metadata") or {}
+    if metadata.get("beacon_alerts") is False:
+        logger.debug(f"Beacon skipped: user {recipient_id} disabled beacon alerts")
+        return {"sent": False, "reachable": False, "reason": "disabled"}
+
+    token = profile.get("push_token")
+    if not token:
+        logger.debug(f"Beacon skipped: user {recipient_id} has no push token")
+        return {"sent": False, "reachable": False, "reason": "missing_token"}
+
+    display_name = sender_name.strip() if sender_name else "A friend"
+    body = f"{display_name} could use some warmth right now."
+    success = send_push(
+        token,
+        "Friendly",
+        body,
+        data={
+            "type": "support_beacon",
+            "friend_id": sender_id,
+            "beacon_user_id": sender_id,
+            "sender_name": display_name,
+        },
+    )
+
+    if not success:
+        return {"sent": False, "reachable": True, "reason": "send_failed"}
+
+    try:
+        repo.create_nudge_log(recipient_id, "support_beacon", body, sender_id)
+    except Exception as e:
+        logger.warning(f"Beacon alert sent but log failed: {e}")
+
+    return {"sent": True, "reachable": True, "reason": "sent"}

--- a/tests/test_beacon_push.py
+++ b/tests/test_beacon_push.py
@@ -1,0 +1,207 @@
+import importlib.util
+import sys
+import types
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _load_signals_module(dispatch_fn):
+    module_names = [
+        "app.db.repository",
+        "app.dependencies",
+        "app.services.push_dispatcher",
+    ]
+    originals = {name: sys.modules.get(name) for name in module_names}
+
+    repo_module = types.ModuleType("app.db.repository")
+    repo_module.Repository = type("Repository", (), {})
+    deps_module = types.ModuleType("app.dependencies")
+    deps_module.get_current_user_id = lambda: "user-1"
+    deps_module.get_repository = lambda: repo_module.Repository()
+    push_module = types.ModuleType("app.services.push_dispatcher")
+    push_module.dispatch_beacon_alert = dispatch_fn
+
+    sys.modules["app.db.repository"] = repo_module
+    sys.modules["app.dependencies"] = deps_module
+    sys.modules["app.services.push_dispatcher"] = push_module
+
+    module_path = Path(__file__).resolve().parents[1] / "app" / "routers" / "signals.py"
+    spec = importlib.util.spec_from_file_location("signals_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+    return module
+
+
+class FakeBeaconRepo:
+    def __init__(self, *, signals=None):
+        self.signals = signals or {}
+        self.created_signals = []
+        self.friendships = [
+            {"user_id": "user-1", "friend_id": "friend-1", "status": "confirmed"},
+            {"user_id": "user-1", "friend_id": "friend-2", "status": "pending"},
+            {"user_id": "friend-3", "friend_id": "user-1", "status": "confirmed"},
+        ]
+        self.profiles = {
+            "user-1": {"id": "user-1", "display_name": "Kyle"},
+            "friend-1": {"id": "friend-1", "display_name": "Liz"},
+            "friend-3": {"id": "friend-3", "display_name": "Sam"},
+        }
+
+    def list_ambient_signals(self, user_id, limit=50):
+        return self.signals.get(user_id, [])
+
+    def create_ambient_signal(self, user_id, signal_type, value, tags=None):
+        row = {
+            "id": "signal-1",
+            "user_id": user_id,
+            "signal_type": signal_type,
+            "value": value,
+            "tags": tags or [],
+            "created_at": "2026-06-01T22:54:32+00:00",
+        }
+        self.created_signals.append(row)
+        return row
+
+    def list_friendships(self, user_id):
+        return self.friendships
+
+    def get_profile(self, user_id):
+        return self.profiles.get(user_id)
+
+
+class BeaconRouteTests(unittest.TestCase):
+    def test_new_beacon_notifies_confirmed_friends_only(self):
+        calls = []
+
+        def fake_dispatch(repo, recipient_id, sender_id, sender_name):
+            calls.append((recipient_id, sender_id, sender_name))
+            return {"sent": True, "reachable": True, "reason": "sent"}
+
+        signals = _load_signals_module(fake_dispatch)
+        repo = FakeBeaconRepo()
+
+        response = signals.activate_beacon(user_id="user-1", repo=repo)
+
+        self.assertTrue(response.active)
+        self.assertEqual(response.notified_count, 2)
+        self.assertEqual(response.reachable_friends, 2)
+        self.assertEqual(
+            calls,
+            [
+                ("friend-1", "user-1", "Kyle"),
+                ("friend-3", "user-1", "Kyle"),
+            ],
+        )
+        self.assertEqual(len(repo.created_signals), 1)
+
+    def test_existing_active_beacon_does_not_resend_pushes(self):
+        calls = []
+        active_signal = {
+            "id": "signal-active",
+            "user_id": "user-1",
+            "signal_type": "support_beacon",
+            "value": 1.0,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        def fake_dispatch(repo, recipient_id, sender_id, sender_name):
+            calls.append((recipient_id, sender_id, sender_name))
+            return {"sent": True, "reachable": True, "reason": "sent"}
+
+        signals = _load_signals_module(fake_dispatch)
+        repo = FakeBeaconRepo(signals={"user-1": [active_signal]})
+
+        response = signals.activate_beacon(user_id="user-1", repo=repo)
+
+        self.assertTrue(response.active)
+        self.assertEqual(response.activated_at, active_signal["created_at"])
+        self.assertEqual(response.notified_count, 0)
+        self.assertEqual(calls, [])
+        self.assertEqual(repo.created_signals, [])
+
+
+class FakePushRepo:
+    def __init__(self, profile):
+        self.profile = profile
+        self.logs = []
+
+    def get_profile(self, user_id):
+        return self.profile
+
+    def create_nudge_log(self, user_id, nudge_tier, copy_text, friend_id=None):
+        self.logs.append((user_id, nudge_tier, copy_text, friend_id))
+        return {}
+
+
+class BeaconDispatcherTests(unittest.TestCase):
+    def test_beacon_alert_respects_recipient_preference(self):
+        from app.services import push_dispatcher
+
+        sent = []
+        original_send_push = push_dispatcher.send_push
+        push_dispatcher.send_push = lambda *args, **kwargs: sent.append((args, kwargs)) or True
+        try:
+            repo = FakePushRepo({
+                "id": "friend-1",
+                "push_token": "token-1",
+                "metadata": {"beacon_alerts": False},
+            })
+
+            result = push_dispatcher.dispatch_beacon_alert(
+                repo,
+                recipient_id="friend-1",
+                sender_id="user-1",
+                sender_name="Kyle",
+            )
+        finally:
+            push_dispatcher.send_push = original_send_push
+
+        self.assertEqual(result["reason"], "disabled")
+        self.assertFalse(result["sent"])
+        self.assertEqual(sent, [])
+        self.assertEqual(repo.logs, [])
+
+    def test_beacon_alert_sends_and_logs_when_reachable(self):
+        from app.services import push_dispatcher
+
+        sent = []
+        original_send_push = push_dispatcher.send_push
+        push_dispatcher.send_push = lambda *args, **kwargs: sent.append((args, kwargs)) or True
+        try:
+            repo = FakePushRepo({
+                "id": "friend-1",
+                "push_token": "token-1",
+                "metadata": {},
+            })
+
+            result = push_dispatcher.dispatch_beacon_alert(
+                repo,
+                recipient_id="friend-1",
+                sender_id="user-1",
+                sender_name="Kyle",
+            )
+        finally:
+            push_dispatcher.send_push = original_send_push
+
+        self.assertTrue(result["sent"])
+        self.assertEqual(result["reason"], "sent")
+        self.assertEqual(len(sent), 1)
+        args, kwargs = sent[0]
+        self.assertEqual(args[0], "token-1")
+        self.assertEqual(args[1], "Friendly")
+        self.assertEqual(args[2], "Kyle could use some warmth right now.")
+        self.assertEqual(kwargs["data"]["type"], "support_beacon")
+        self.assertEqual(repo.logs[0][1], "support_beacon")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- Send FCM support-beacon alerts to confirmed friends when a new beacon is activated.
- Respect each recipient's beacon alert preference and require a registered push token.
- Avoid resending alerts when the activating user already has an active 24-hour beacon.
- Return notified/reachable friend counts in the beacon response.

## Validation
- python3 -m unittest discover -s tests -p 'test*.py' -v
- python3 -m compileall app tests